### PR TITLE
v. 0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 # backup
 *~
 \#*
+/*.tgz
 
 # Backup & old files
 *~
@@ -138,3 +139,4 @@ dmypy.json
 .\#*
 old/
 *.old
+/tmp

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+v. 0.2.1
+ * fix: policy argument passing to process_document() for policies with options
+ * fix: placeholder processing with non-country-specific options
+ * fix: substitution templates with missing fields
+ * added more placeholder values to config
+
 v. 0.2.0
  * API for end-to-end processing of raw text buffers
  * Provide a Python API function for end-to-end document processing
+
+v. 0.1.0
+ * initial version

--- a/doc/api.md
+++ b/doc/api.md
@@ -78,8 +78,24 @@ proc = PiiTextProcessor(lang="en", default_policy="label")
 outbuf = proc(inbuf)
 ```
 
-This is a [thin wrapper] over the relevant objects in the PIISA libraries
+This is a [thin wrapper] over the relevant objects in the PIISA libraries.
+The procedure is:
+ 1. Initialize a `PiiTextProcessor` object, giving as arguments the language
+    the text will be in and the default [policy] to apply to transform the
+	PII instances found
+ 2. Call the object with a text buffer. It will detect PII instances in it
+    and apply the transformation, and will return the transformed text buffer.
+
+Additional process customization is possible by adding a `config` argument to
+the constructor. This will contain a PIISA [configuration], or a list of them,
+that will be used to modify the behaviour of one or more elements in the
+chain. Argument values can be:
+ * filenames holding a configuration (in JSON format)
+ * in-memory configurations, as a Python dictionary
+
+
 
 [policy]: policies.md
 [its implementation]: ../src/pii_transform/api/e2e/document.py
 [thin wrapper]: ../src/pii_transform/api/e2e/textchunk.py
+[configuration]: https://github.com/piisa/piisa/tree/main/docs/configuration.md

--- a/src/pii_transform/__init__.py
+++ b/src/pii_transform/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/src/pii_transform/api/e2e/__init__.py
+++ b/src/pii_transform/api/e2e/__init__.py
@@ -1,2 +1,2 @@
-from .document import process_document, MISSING_LIBS
+from .document import process_document, format_policy, MISSING_LIBS
 from .textchunk import PiiTextProcessor

--- a/src/pii_transform/api/transform.py
+++ b/src/pii_transform/api/transform.py
@@ -2,7 +2,7 @@
 Transform documents by replacing PII instances according to a policy
 """
 
-from typing import Dict
+from typing import Dict, Union
 
 from pii_data.types import PiiCollection
 from pii_data.types.doc import SrcDocument, DocumentChunk, LocalSrcDocument
@@ -16,12 +16,13 @@ from ..helper import PiiSubstitutionValue
 
 class PiiTransformer:
 
-    def __init__(self, default_policy: str = None, config: Dict = None,
-                 debug: bool = False):
+    def __init__(self, default_policy: Union[str, Dict] = None,
+                 config: Dict = None, debug: bool = False):
         """
          :param default_policy: a default policy value to apply to all entities
             that do not have a specific policy
-         :param policy: configurations for transform policy and/or placheholder
+         :param config: full policy configurations to apply
+         :param debug:
         """
         self._debug = debug
         self.subst = PiiSubstitutionValue(default_policy, config)

--- a/src/pii_transform/app/process.py
+++ b/src/pii_transform/app/process.py
@@ -10,7 +10,7 @@ from typing import List
 from .. import VERSION
 from ..helper.substitution import POLICIES
 
-from ..api.e2e import process_document, MISSING_LIBS
+from ..api.e2e import process_document, format_policy, MISSING_LIBS
 
 
 # -------------------------------------------------------------------------
@@ -45,8 +45,8 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     g2 = parser.add_argument_group("Transforming options")
     g2.add_argument("--default-policy", choices=POLICIES,
                     help="Apply a default policy to all entities")
-    g2.add_argument("--hash-key",
-                    help="key value for the hash policy")
+    g2.add_argument("--policy-param",
+                    help="policy specific parameter (e.g. hash key, template)")
 
     g3 = parser.add_argument_group("Other")
     g3.add_argument("--verbose","-v", type=int, default=1,
@@ -65,14 +65,18 @@ def main(args: List[str] = None):
         sys.exit(1)
     if args is None:
         args = sys.argv[1:]
+
     args = parse_args(args)
-    vararg = vars(args)
-    reraise = vararg.pop("reraise")
+    kw = vars(args)
+    reraise = kw.pop("reraise")
+
     try:
-        infile = vararg.pop("infile")
-        outfile = vararg.pop("outfile")
-        piifile = vararg.pop("save_pii")
-        process_document(infile, outfile, piifile=piifile, **vararg)
+        infile = kw.pop("infile")
+        outfile = kw.pop("outfile")
+        piifile = kw.pop("save_pii")
+        defp = format_policy(kw.pop("default_policy"), kw.pop("policy_param"))
+        process_document(infile, outfile, piifile=piifile, default_policy=defp,
+                         **kw)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         if reraise:

--- a/src/pii_transform/helper/placeholder.py
+++ b/src/pii_transform/helper/placeholder.py
@@ -65,6 +65,7 @@ class PlaceholderValue:
         fields = pii.fields
         pii_type = fields["type"]
         elem = self._values.get(pii_type)
+
         if not elem:
             return pii_type
         if isinstance(elem, (list, str)):
@@ -73,6 +74,9 @@ class PlaceholderValue:
         lang = elem.get(pii.info.lang) or elem.get("any")
         if not lang:
             return pii_type
+        if isinstance(lang, (list, str)):
+            return lang
+
         country = lang.get(pii.info.country) or lang.get("any")
         return country or pii_type
 

--- a/src/pii_transform/helper/substitution.py
+++ b/src/pii_transform/helper/substitution.py
@@ -63,16 +63,23 @@ def policy_target(target: Union[str, PiiEnum]) -> str:
         raise InvArgException('invalid policy target: {}', target)
 
 
+class DefaultEmpty(dict):
+    """
+    A dict that returns an emoty string on missing keys
+    """
+    def __missing__(self, key):
+        return ""
+
 
 class PiiSubstitutionValue:
 
-    def __init__(self, default_policy: str = None, config: Dict = None):
+    def __init__(self, default_policy: Union[str, Dict] = None,
+                 config: Dict = None):
         """
          :param policy: a default policy to apply to all entities that do
-            not have a specific policy
-         :param policy: a detailed policy per entity type
-         :param placeholder: values for the placeholder policy
-         """
+            not have a specific policy in the configuration
+         :param config: configuration to apply
+        """
         self._config = config
         self._ph = None
 
@@ -136,6 +143,6 @@ class PiiSubstitutionValue:
         """
         v = self._assign.get(pii.fields["type"]) or self._assign["default"]
         if isinstance(v, str):
-            return v.format(**pii.fields)
+            return v.format_map(DefaultEmpty(pii.asdict()))
         else:
             return v(pii)

--- a/src/pii_transform/resources/placeholder.json
+++ b/src/pii_transform/resources/placeholder.json
@@ -1,6 +1,8 @@
 {
   "format": "piisa:config:pii-transform:placeholder:v1",
   "placeholder_values": {
+
+
     "EMAIL_ADDRESS": [
       "redacted.email@gmail.com",
       "redacted.email@hotmail.com",
@@ -8,11 +10,42 @@
       "redacted.email@aol.com",
       "redacted.email@yahoo.com"
     ],
+
+
+    "GOV_ID": {
+      "any": "00111222",
+      "en": {
+	"us": "000-11-1234"
+      },
+      "es": {
+	"es": ["12345678Z", "11111111H"]
+      }
+    },
+
+
+    "PHONE_NUMBER": {
+      "any": "+00 0 1234 5678",
+      "en": {
+	"us": [
+	  "(000) 123-456", "(001) 123-456", "(002) 123-456", "(003) 123-456"
+	]
+      },
+      "es": {
+	"any": "00 0000 0000",
+	"es": [
+	  "999 123 456", "999 000 000", "998 123 456", "998 123 456"
+	]
+      }
+    },
+
+
     "CREDIT_CARD": [
       "0123 0123 0123 0123",
       "9999 9999 9999 9999",
       "0000 0000 0000 0000"
     ],
+
+
     "PERSON": {
       "en": {
 	"any": ["John Doe", "Jane Doe"],

--- a/test/unit/helper/test_placeholder.py
+++ b/test/unit/helper/test_placeholder.py
@@ -18,24 +18,24 @@ def test10_constructor():
     Test constructing the object with default file
     """
     m = mod.PlaceholderValue()
-    assert str(m) == "<PlaceholderValue: #3>"
+    assert str(m) == "<PlaceholderValue: #5>"
 
 
 def test11_constructor_file():
     """
-    Test constructing the object with specific file
+    Test constructing the object with specific config file
     """
     m = mod.PlaceholderValue(config=datafile("placeholder-test.json"))
-    assert str(m) == "<PlaceholderValue: #4>"
+    assert str(m) == "<PlaceholderValue: #6>"
 
 
 def test12_constructor_data():
     """
-    Test constructing the object with specific file
+    Test constructing the object with specific config data
     """
     config = load_config(datafile("placeholder-test.json"))
     m = mod.PlaceholderValue(config=config)
-    assert str(m) == "<PlaceholderValue: #4>"
+    assert str(m) == "<PlaceholderValue: #6>"
 
 
 def test20_value():

--- a/test/unit/helper/test_substitution.py
+++ b/test/unit/helper/test_substitution.py
@@ -94,6 +94,20 @@ def test140_custom():
         assert m(pii) == f"{p.name}=1234 5678 (43)"
 
 
+def test141_custom_missing():
+    """
+    Test constructing the object, set custom policy, missing fields
+    """
+    policy = {"name": "custom",
+              "template": "{type}={value} ({chunkid}) pos={start} <{country}>"}
+    m = mod.PiiSubstitutionValue(default_policy=policy)
+
+    for n, p in enumerate((PiiEnum.CREDIT_CARD, PiiEnum.BLOCKCHAIN_ADDRESS,
+                           PiiEnum.BANK_ACCOUNT)):
+        pii = PiiEntity.build(p, "1234 5678", "43", n)
+        assert m(pii) == f"{p.name}=1234 5678 (43) pos={n} <>"
+
+
 def test150_hash():
     """
     Test constructing the object, set hash policy


### PR DESCRIPTION
 * fix: policy argument passing to `process_document()` for policies with options
 * fix: placeholder processing with non-country-specific options
 * fix: substitution templates with missing fields
 * added more placeholder values to config